### PR TITLE
Add Beaglebone quick setup files

### DIFF
--- a/Bonesetup/00_Bonesetup.sh
+++ b/Bonesetup/00_Bonesetup.sh
@@ -23,7 +23,7 @@ source /opt/ros/kinetic/setup.bash
 # so as to to overlay the next ROS node over the previous one
 # Failing to do so will result in some of the packages not being detected by ROS 
 
-git clone https://github.com/yonahbox/Yonah_ROS_packages.git
+git clone https://github.com/yonahbox/Yonah_ROS_packages.git ~/Yonah_ROS_packages
 
 # air_data
 bash 02_addROSpackages.sh bonedata_ws air_data
@@ -43,4 +43,10 @@ bash 03_removepackages.sh
 
 ##########################################
 
-echo "Setup complete, please reload the bashrc using source ~/.bashrc"
+echo "
+Setup complete, please do the following:
+
+1. Reload the bashrc using source ~/.bashrc
+2. Add a whitelist.txt into ~/Yonah_ROS_Packages/bonesms_ws/src/air_sms/src/
+3. Add the AWS Private Keys into ~/Yonah_ROS_Packages/bonedata_ws/src/air_data/src/
+"

--- a/Bonesetup/00_Bonesetup.sh
+++ b/Bonesetup/00_Bonesetup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Full process for the initial setup of a brand new Beaglebone
+
+##########################################
+
+# Step 1: Install initial packages (e.g. ROS, MAVROS)
+
+# Note that a "source" command after compiling each ROS pacakge is neccessary, so that
+# the next ROS node can be overlaid over the previous one
+
+bash 01_installpackages.sh
+source /opt/ros/kinetic/setup.bash
+
+##########################################
+
+# Step 2: Download Yonah's ROS packages and compile them one by one
+
+# For each ROS package, "addROSpackages.sh" is called, with the workspace and package names
+# passed into the shellfile as arguments
+
+# Again, note that the "source" command is required after each compilation,
+# so as to to overlay the next ROS node over the previous one
+# Failing to do so will result in some of the packages not being detected by ROS 
+
+git clone https://github.com/yonahbox/Yonah_ROS_packages.git
+
+# air_data
+bash 02_addROSpackages.sh bonedata_ws air_data
+source ~/Yonah_ROS_packages/bonedata_ws/devel/setup.bash
+
+# air_sms
+bash 02_addROSpackages.sh bonesms_ws air_sms
+source ~/Yonah_ROS_packages/bonesms_ws/devel/setup.bash
+
+# To add new packages, just copy the lines above and specify the workspace and package name accordingly
+
+##########################################
+
+#Step 3: Remove unncessary packages
+
+bash 03_removepackages.sh
+
+##########################################
+
+echo "Setup complete, please reload the bashrc using source ~/.bashrc"

--- a/Bonesetup/01_installpackages.sh
+++ b/Bonesetup/01_installpackages.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Set up ROS and other relevant packages on Beaglebone Black
+# See https://subscription.packtpub.com/book/hardware_and_creative/9781786463654/1/ch01lvl1sec12/installing-ros-in-beaglebone-black
+
+# Step 1: Set up the local machine and the source.list file
+sudo apt-get update
+sudo update-locale LANG=C LANGUAGE=C LC_ALL=C LC_MESSAGES=POSIX
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros-latest.list'
+
+# Step 2: Set up your keys
+sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net --recv-key 0xB01FA116
+
+# Step 3: Install ROS packages, rosdep, and add setup.bash to bashrc
+sudo apt-get update
+sudo apt-get install ros-kinetic-ros-base
+sudo apt-get install python-rosdep
+sudo rosdep init
+rosdep update
+echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
+
+# Step 4: Install MAVROS packages
+# See http://ardupilot.org/dev/docs/ros-install.html
+sudo apt-get install ros-kinetic-mavros ros-kinetic-mavros-extras
+wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh
+chmod a+x install_geographiclib_datasets.sh
+bash install_geographiclib_datasets.sh
+sudo apt-get install python-catkin-tools
+
+# Step 5: Install packages to make MAVROS/ROS compatible with python3
+# See https://medium.com/@beta_b0t/how-to-setup-ros-with-python-3-44a69ca36674
+sudo apt-get install python3-pip python3-yaml
+sudo pip3 install rospkg catkin_pkg defusedxml
+
+# Step 6: Install non-ROS packages: htop, git, tmux and nmap (netcat)
+sudo apt-get install htop git tmux nmap
+
+# Step 7: Configure timezone to Singapore time
+# See https://www.tecmint.com/set-time-timezone-and-synchronize-time-using-timedatectl-command/
+timedatectl set-timezone "Asia/Singapore"

--- a/Bonesetup/02_addROSpackages.sh
+++ b/Bonesetup/02_addROSpackages.sh
@@ -13,16 +13,21 @@ elif [ ! -d "$HOME/Yonah_ROS_packages/$1" ]; then
 elif [ ! -d "$HOME/Yonah_ROS_packages/$1/src/$2" ]; then
     echo "$HOME/Yonah_ROS_packages/$1/src/$2 directory not found, exiting!"
 else
+    # Compile the workspace with cmake, add it to bashrc, and then prepare for catkin_create_pkg
     cd ~/Yonah_ROS_packages/$1
     catkin_make
     echo "source ~/Yonah_ROS_packages/$1/devel/setup.bash" >> ~/.bashrc
     cd src
-    # Note that the below set of commands (moving air_data folder) are a "hack" to get past the "file exists" error
-    # when running catkin_create_pkg. It's a very ugly method, but it works...
+    # Note that the below set of commands are a "hack" to get past the "file exists" error
+    # when running catkin_create_pkg. The idea is to move the package folder temporarily to
+    # the root location, run catkin_create_pkg to generate the package, and then shift the
+    # contents of the original package folder into the newly generated package. Finally, the 
+    # original package folder is deleted. It's a very ugly method, but it works...
     mv $2 ~/
     catkin_create_pkg $2 std_msgs rospy
     mv ~/$2/* ./$2/
     rm -r ~/$2
+    # Finally, re-compile the workspace with the newly generated package
     cd ~/Yonah_ROS_packages/$1
     catkin_make
 fi

--- a/Bonesetup/02_addROSpackages.sh
+++ b/Bonesetup/02_addROSpackages.sh
@@ -2,15 +2,27 @@
 
 # Initialise a ROS node downloaded from Yonah's Github
 # The workspace and package name is specified as the 1st and 2nd arguments
-# Note that the last 6 set of commands (moving air_data folder) are a "hack" to get past the "file exists" error
-# when running catkin_create_pkg. It's a very ugly method, but it works...
-cd ~/Yonah_ROS_packages/$1
-catkin_make
-echo "source ~/Yonah_ROS_packages/$1/devel/setup.bash" >> ~/.bashrc
-cd src
-mv $2 ~/
-catkin_create_pkg $2 std_msgs rospy
-mv ~/$2/* ./$2/
-rm -r ~/$2
-cd ~/Yonah_ROS_packages/$1
-catkin_make
+# The script is not run if:
+#   1. Either of the arguments are not provided
+#   2. The workspace and package directories don't exist
+if [ -z "$1" -o -z "$2" ]; then
+    echo "Usage: bash 02_addROSpackages.sh <workspace name> <package name>.
+        Make sure your workspace and package folders exist!"
+elif [ ! -d "$HOME/Yonah_ROS_packages/$1" ]; then
+    echo "$HOME/Yonah_ROS_packages/$1 directory not found, exiting!"
+elif [ ! -d "$HOME/Yonah_ROS_packages/$1/src/$2" ]; then
+    echo "$HOME/Yonah_ROS_packages/$1/src/$2 directory not found, exiting!"
+else
+    cd ~/Yonah_ROS_packages/$1
+    catkin_make
+    echo "source ~/Yonah_ROS_packages/$1/devel/setup.bash" >> ~/.bashrc
+    cd src
+    # Note that the below set of commands (moving air_data folder) are a "hack" to get past the "file exists" error
+    # when running catkin_create_pkg. It's a very ugly method, but it works...
+    mv $2 ~/
+    catkin_create_pkg $2 std_msgs rospy
+    mv ~/$2/* ./$2/
+    rm -r ~/$2
+    cd ~/Yonah_ROS_packages/$1
+    catkin_make
+fi

--- a/Bonesetup/02_addROSpackages.sh
+++ b/Bonesetup/02_addROSpackages.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Initialise a ROS node downloaded from Yonah's Github
+# The workspace and package name is specified as the 1st and 2nd arguments
+# Note that the last 6 set of commands (moving air_data folder) are a "hack" to get past the "file exists" error
+# when running catkin_create_pkg. It's a very ugly method, but it works...
+cd ~/Yonah_ROS_packages/$1
+catkin_make
+echo "source ~/Yonah_ROS_packages/$1/devel/setup.bash" >> ~/.bashrc
+cd src
+mv $2 ~/
+catkin_create_pkg $2 std_msgs rospy
+mv ~/$2/* ./$2/
+rm -r ~/$2
+cd ~/Yonah_ROS_packages/$1
+catkin_make

--- a/Bonesetup/03_removepackages.sh
+++ b/Bonesetup/03_removepackages.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Removes unnecessary packages from the Bone
+sudo apt-get remove apache avahi bison bzip2 colord flex fontconfig graphviz humanity-icon-theme manpages-dev notification-daemon pastebinit

--- a/Bonesetup/03_removepackages.sh
+++ b/Bonesetup/03_removepackages.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
 
 # Removes unnecessary packages from the Bone
-sudo apt-get remove apache avahi bison bzip2 colord flex fontconfig graphviz humanity-icon-theme manpages-dev notification-daemon pastebinit
+sudo apt-get remove apache2 avahi-daemon bison colord flex manpages-dev notification-daemon pastebinit
+sudo apt-get autoremove
+
+# autoremove will remove the following packages:
+# acl adwaita-icon-theme at-spi2-core colord-data dconf-gsettings-backend dconf-service glib-networking glib-networking-common glib-networking-services
+# gsettings-desktop-schemas humanity-icon-theme libatk-bridge2.0-0 libatspi2.0-0 libbison-dev libcairo-gobject2 libcapnp-0.5.3 libcolord2 libcolorhug2
+# libdconf1 libegl1-mesa libepoxy0 libexif12 libfl-dev libgbm1 libgphoto2-6 libgphoto2-l10n libgphoto2-port12 libgtk-3-0 libgtk-3-bin libgtk-3-common
+# libgudev-1.0-0 libgusb2 libieee1284-3 libjson-glib-1.0-0 libjson-glib-1.0-common libmirclient9 libmircommon7 libmircore1 libmirprotobuf3
+# libpolkit-agent-1-0 libpolkit-backend-1-0 libpolkit-gobject-1-0 libprotobuf-lite9v5 libproxy1v5 librest-0.7-0 libsane libsane-common libsigsegv2
+# libsoup-gnome2.4-1 libsoup2.4-1 libwayland-client0 libwayland-cursor0 libwayland-egl1-mesa libwayland-server0 libxcb-xfixes0 libxkbcommon0 libxtst6
+# m4 policykit-1 ssl-cert ubuntu-mono
+
+# Remark: This frees 7703kb (first command) + 66.2mb (2nd command) of disk space

--- a/Bonesetup/Readme.md
+++ b/Bonesetup/Readme.md
@@ -27,3 +27,21 @@ Steps 2 - 4 can be automated using scripts in this folder
     * Add a whitelist file (with the title `whitelist.txt`) into `~/Yonah_ROS_Packages/bonesms_ws/src/air_sms/src/` location in the Beaglebone, so that air_sms can use it to recognise whitelisted phone numbers. Refer to the air_sms [Readme](https://github.com/yonahbox/Yonah_ROS_packages/tree/master/bonesms_ws) on instructions on how to setup `whitelist.txt`
     * Add the AWS Private Keys into `~/Yonah_ROS_Packages/bonedata_ws/src/air_data/src/` location in the Beaglebone, so that air_data can use it to connect to the AWS instance
 * Note that all of Yonah's ROS packages will be located in the `~/Yonah_ROS_Packages` folder
+
+## Re-setup procedures
+
+If for any reason you need to re-run any of the scripts (e.g. re-download Yonah's ROS packages), go into `00_Bonesetup.sh` and comment out the unncessary parts. For example, to re-download and re-compile Yonah's ROS packages, go into `00_Bonesetup.sh`, and comment out everything except the following block of code:
+
+```
+git clone https://github.com/yonahbox/Yonah_ROS_packages.git ~/Yonah_ROS_packages
+
+# air_data
+bash 02_addROSpackages.sh bonedata_ws air_data
+source ~/Yonah_ROS_packages/bonedata_ws/devel/setup.bash
+
+# air_sms
+bash 02_addROSpackages.sh bonesms_ws air_sms
+source ~/Yonah_ROS_packages/bonesms_ws/devel/setup.bash
+```
+
+Then remove any relevant lines from your `.bashrc` (e.g. `source ~/Yonah_ROS_packages/bonedata_ws/devel/setup.bash`), reload the `.bashrc`, and then rerun `00_Bonesetup.sh`

--- a/Bonesetup/Readme.md
+++ b/Bonesetup/Readme.md
@@ -1,24 +1,25 @@
 # Bonesetup
 
-Contains scripts that will automate the initial setup of the Beaglebone Black Companion Computer. The installation steps are found [here](https://subscription.packtpub.com/book/hardware_and_creative/9781786463654/1/ch01lvl1sec12/installing-ros-in-beaglebone-black)
+Contains scripts that will automate the initial setup of the Beaglebone Black Companion Computer. The installation steps are found [in this guide](https://subscription.packtpub.com/book/hardware_and_creative/9781786463654/1/ch01lvl1sec12/installing-ros-in-beaglebone-black)
 
 There are four main tasks to be performed during the initial setup (minus the hardware setup component):
 
 1. Flashing the SD card and inserting it into the Beaglebone
 2. Installing ROS, MAVROS and other neccessary packages
-3. Adding ROS nodes from [Yonah_ROS_Packages](https://github.com/yonahbox/Yonah_ROS_packages.git)
+3. Adding ROS packages from [Yonah_ROS_Packages](https://github.com/yonahbox/Yonah_ROS_packages.git)
 4. Removing unnecessary packages
 
 Steps 2 - 4 can be automated using scripts in this folder
 
 ## Bone setup procedure
 
-* Follow the installation steps mentioned in the above link
+* Follow the installation steps mentioned in [in the above guide](https://subscription.packtpub.com/book/hardware_and_creative/9781786463654/1/ch01lvl1sec12/installing-ros-in-beaglebone-black)
 * Note that When booting up for the first time in SD card (and pressing F2 button), you need to wait for a few minutes before you can ssh into the bone
+    * To learn how to ssh into the Bone over USB, refer to the following [link](https://www.dummies.com/computers/beaglebone/how-to-connect-your-beaglebone-via-ssh-over-usb/).
 * Make sure the Bone is connected to the Internet (through a LAN cable connected to a router) before installing packages
-* Follow the steps up to and including the part where you add "restricted" to sources.list (i.e. `sudo vi /etc/apt/sources.list` followed by `deb http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe multiverse`, etc)
-    * Note: There is no need to do the memory re-partitioning step mentioned in the link
+* Follow the steps in the guide up to and including the part where you add "restricted" to sources.list (i.e. `sudo vi /etc/apt/sources.list` followed by `deb http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe multiverse`, etc)
+    * Note: There is no need to do the memory re-partitioning step mentioned in the guide
 * Afterwards, use the scripts in this folder to automate the rest of the setup process. Download the Bonesetup folder, copy it into the Bone's root folder (using `scp` command), and run the 00_Bonesetup script with `bash 00_Bonesetup.sh`
     * Note: Make sure all the scripts in this folder are copied to the same location in the Beaglebone (e.g. all located in the Bone's root folder)
 * Respond "Yes" or enter password whenever the system prompts you to do so
-* After the script is complete, reload the .bashrc with `source .bashrc` so that the ROS packages can be recognised
+* After the script is complete, reload the .bashrc with `source ~/.bashrc` so that the ROS packages can be recognised

--- a/Bonesetup/Readme.md
+++ b/Bonesetup/Readme.md
@@ -1,0 +1,24 @@
+# Bonesetup
+
+Contains scripts that will automate the initial setup of the Beaglebone Black Companion Computer. The installation steps are found [here](https://subscription.packtpub.com/book/hardware_and_creative/9781786463654/1/ch01lvl1sec12/installing-ros-in-beaglebone-black)
+
+There are four main tasks to be performed during the initial setup (minus the hardware setup component):
+
+1. Flashing the SD card and inserting it into the Beaglebone
+2. Installing ROS, MAVROS and other neccessary packages
+3. Adding ROS nodes from [Yonah_ROS_Packages](https://github.com/yonahbox/Yonah_ROS_packages.git)
+4. Removing unnecessary packages
+
+Steps 2 - 4 can be automated using scripts in this folder
+
+## Bone setup procedure
+
+* Follow the installation steps mentioned in the above link
+* Note that When booting up for the first time in SD card (and pressing F2 button), you need to wait for a few minutes before you can ssh into the bone
+* Make sure the Bone is connected to the Internet (through a LAN cable connected to a router) before installing packages
+* Follow the steps up to and including the part where you add "restricted" to sources.list (i.e. `sudo vi /etc/apt/sources.list` followed by `deb http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted universe multiverse`, etc)
+    * Note: There is no need to do the memory re-partitioning step mentioned in the link
+* Afterwards, use the scripts in this folder to automate the rest of the setup process. Download the Bonesetup folder, copy it into the Bone's root folder (using `scp` command), and run the 00_Bonesetup script with `bash 00_Bonesetup.sh`
+    * Note: Make sure all the scripts in this folder are copied to the same location in the Beaglebone (e.g. all located in the Bone's root folder)
+* Respond "Yes" or enter password whenever the system prompts you to do so
+* After the script is complete, reload the .bashrc with `source .bashrc` so that the ROS packages can be recognised

--- a/Bonesetup/Readme.md
+++ b/Bonesetup/Readme.md
@@ -22,4 +22,8 @@ Steps 2 - 4 can be automated using scripts in this folder
 * Afterwards, use the scripts in this folder to automate the rest of the setup process. Download the Bonesetup folder, copy it into the Bone's root folder (using `scp` command), and run the 00_Bonesetup script with `bash 00_Bonesetup.sh`
     * Note: Make sure all the scripts in this folder are copied to the same location in the Beaglebone (e.g. all located in the Bone's root folder)
 * Respond "Yes" or enter password whenever the system prompts you to do so
-* After the script is complete, reload the .bashrc with `source ~/.bashrc` so that the ROS packages can be recognised
+* After the script is complete, carry out the following:
+    * Reload the .bashrc with `source ~/.bashrc` so that the ROS packages can be recognised
+    * Add a whitelist file (with the title `whitelist.txt`) into `~/Yonah_ROS_Packages/bonesms_ws/src/air_sms/src/` location in the Beaglebone, so that air_sms can use it to recognise whitelisted phone numbers
+    * Add the AWS Private Keys into `~/Yonah_ROS_Packages/bonedata_ws/src/air_data/src/` location in the Beaglebone, so that air_data can use it to connect to the AWS instance
+* Note that all of Yonah's ROS packages will be located in the `~/Yonah_ROS_Packages` folder

--- a/Bonesetup/Readme.md
+++ b/Bonesetup/Readme.md
@@ -24,6 +24,6 @@ Steps 2 - 4 can be automated using scripts in this folder
 * Respond "Yes" or enter password whenever the system prompts you to do so
 * After the script is complete, carry out the following:
     * Reload the .bashrc with `source ~/.bashrc` so that the ROS packages can be recognised
-    * Add a whitelist file (with the title `whitelist.txt`) into `~/Yonah_ROS_Packages/bonesms_ws/src/air_sms/src/` location in the Beaglebone, so that air_sms can use it to recognise whitelisted phone numbers
+    * Add a whitelist file (with the title `whitelist.txt`) into `~/Yonah_ROS_Packages/bonesms_ws/src/air_sms/src/` location in the Beaglebone, so that air_sms can use it to recognise whitelisted phone numbers. Refer to the air_sms [Readme](https://github.com/yonahbox/Yonah_ROS_packages/tree/master/bonesms_ws) on instructions on how to setup `whitelist.txt`
     * Add the AWS Private Keys into `~/Yonah_ROS_Packages/bonedata_ws/src/air_data/src/` location in the Beaglebone, so that air_data can use it to connect to the AWS instance
 * Note that all of Yonah's ROS packages will be located in the `~/Yonah_ROS_Packages` folder

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Custom scripts to automate menial tasks during development, flight, and ops
 
 ## List of files and folders
-* home: Contains files that should be included in the GCS home directory (e.g. .mavinit.scr)
-* GCS: Folder for running all GCS related tools (e.g. MAVProxy, data telem, SMS telem scripts)
 * AWS: Files that will be run on Yonah's Amazon Web Server EC2 Instance.
+* Bonesetup: Contains scripts that will automate the initial setup of the Beaglebone Black Companion Computer.
+* GCS: Folder for running all GCS related tools (e.g. MAVProxy, data telem, SMS telem scripts)
+* home: Contains files that should be included in the GCS home directory (e.g. .mavinit.scr)


### PR DESCRIPTION
This is a set of shell scripts to automate the (complicated) setup process in a new Beaglebone Black. Instructions on how to setup are in the Readme.

Cloning our ROS packages directly from Yonah_ROS_packages (see https://github.com/yonahbox/Yonah_ROS_packages/pull/7) allows us to perform a quick git clone/pull directly into the Beaglebone when updating our onboard ROS packages. This necessitates some minor file location changes in the Beaglebone, which is addressed in the pull request linked above.